### PR TITLE
Not use 'go.mod'

### DIFF
--- a/backend/route.go
+++ b/backend/route.go
@@ -1,1 +1,7 @@
 package backend
+
+import "github.com/labstack/echo"
+
+func Route() {
+	e := echo.New()
+}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func main() {
+	name := "Jimmy"
+	fmt.Printf("私の名前は %s です", name)
+}


### PR DESCRIPTION
go1.11 からの go mod を使用しようとしたところ、予想以上にハマったため、後回しにする。
まずは機能実装に注力していきたいため、ライブラリ管理は従来通り vendor などに頼る形んありそう。

必要なものはその都度、go get -u していくスタイル。